### PR TITLE
figures/Kepler.ipynb: fix the url of the .fits file, the archive now …

### DIFF
--- a/figures/Kepler.ipynb
+++ b/figures/Kepler.ipynb
@@ -31,7 +31,7 @@
    },
    "outputs": [],
    "source": [
-    "# !curl -O http://archive.stsci.edu/pub/kepler/lightcurves/0071/007198959/kplr007198959-2009259160929_llc.fits"
+    "# !curl -O https://archive.stsci.edu/pub/kepler/lightcurves/0071/007198959/kplr007198959-2009259160929_llc.fits"
    ]
   },
   {


### PR DESCRIPTION
…uses https instead of http.