### PR TITLE
Fix astropy warning

### DIFF
--- a/figures/Baluev.ipynb
+++ b/figures/Baluev.ipynb
@@ -18,7 +18,7 @@
     "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from astropy.stats import LombScargle\n",
+    "from astropy.timeseries import LombScargle\n",
     "\n",
     "plt.style.use('seaborn-whitegrid')"
    ]

--- a/figures/BayesianPeriodogram.ipynb
+++ b/figures/BayesianPeriodogram.ipynb
@@ -12,7 +12,7 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import pandas as pd\n",
-    "from astropy.stats import LombScargle\n",
+    "from astropy.timeseries import LombScargle\n",
     "\n",
     "plt.style.use('seaborn-whitegrid')"
    ]

--- a/figures/Convolutions.ipynb
+++ b/figures/Convolutions.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from astropy.stats import LombScargle\n",
+    "from astropy.timeseries import LombScargle\n",
     "\n",
     "plt.style.use('seaborn-whitegrid')"
    ]

--- a/figures/FailureModes.ipynb
+++ b/figures/FailureModes.ipynb
@@ -22,7 +22,7 @@
     "plt.style.use('seaborn-whitegrid')\n",
     "\n",
     "import numpy as np\n",
-    "from astropy.stats import LombScargle"
+    "from astropy.timeseries import LombScargle"
    ]
   },
   {

--- a/figures/FloatingMean.ipynb
+++ b/figures/FloatingMean.ipynb
@@ -52,7 +52,7 @@
     }
    ],
    "source": [
-    "from astropy.stats import LombScargle\n",
+    "from astropy.timeseries import LombScargle\n",
     "\n",
     "ls_standard = LombScargle(t, y, dy, fit_mean=False)\n",
     "ls_generalized = LombScargle(t, y, dy, fit_mean=True)\n",

--- a/figures/Kepler.ipynb
+++ b/figures/Kepler.ipynb
@@ -31,7 +31,7 @@
    },
    "outputs": [],
    "source": [
-    "# !curl -O http://archive.stsci.edu/pub/kepler/lightcurves/0071/007198959/kplr007198959-2009259160929_llc.fits"
+    "# !curl -O https://archive.stsci.edu/pub/kepler/lightcurves/0071/007198959/kplr007198959-2009259160929_llc.fits"
    ]
   },
   {

--- a/figures/Kepler.ipynb
+++ b/figures/Kepler.ipynb
@@ -368,7 +368,7 @@
     "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from astropy.stats import LombScargle\n",
+    "from astropy.timeseries import LombScargle\n",
     "\n",
     "plt.style.use('seaborn-whitegrid')"
    ]
@@ -388,7 +388,7 @@
    },
    "outputs": [],
    "source": [
-    "from astropy.stats import LombScargle"
+    "from astropy.timeseries import LombScargle"
    ]
   },
   {

--- a/figures/LINEAR_Example.ipynb
+++ b/figures/LINEAR_Example.ipynb
@@ -216,7 +216,7 @@
    },
    "outputs": [],
    "source": [
-    "from astropy.stats import LombScargle\n",
+    "from astropy.timeseries import LombScargle\n",
     "ls = LombScargle(data.t, data.mag, data.magerr)\n",
     "frequency, power = ls.autopower(nyquist_factor=500,\n",
     "                                minimum_frequency=0.2)\n",

--- a/figures/LINEAR_binary.ipynb
+++ b/figures/LINEAR_binary.ipynb
@@ -158,7 +158,7 @@
     }
    ],
    "source": [
-    "from astropy.stats import LombScargle\n",
+    "from astropy.timeseries import LombScargle\n",
     "ls_window = LombScargle(data.t, 1, fit_mean=False, center_data=False)\n",
     "freq, power = ls_window.autopower(minimum_frequency=0.001,\n",
     "                                  maximum_frequency=10)\n",

--- a/figures/LombScargleVsClassical.ipynb
+++ b/figures/LombScargleVsClassical.ipynb
@@ -12,7 +12,7 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import pandas as pd\n",
-    "from astropy.stats import LombScargle\n",
+    "from astropy.timeseries import LombScargle\n",
     "\n",
     "plt.style.use('seaborn-whitegrid')"
    ]

--- a/figures/MultiTerm.ipynb
+++ b/figures/MultiTerm.ipynb
@@ -11,7 +11,7 @@
     "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from astropy.stats import LombScargle\n",
+    "from astropy.timeseries import LombScargle\n",
     "\n",
     "plt.style.use('seaborn-whitegrid')"
    ]

--- a/figures/PseudoNyquist.ipynb
+++ b/figures/PseudoNyquist.ipynb
@@ -112,7 +112,7 @@
    },
    "outputs": [],
    "source": [
-    "from astropy.stats import LombScargle\n",
+    "from astropy.timeseries import LombScargle\n",
     "ls = LombScargle(data.t, data.mag, data.magerr)\n",
     "frequency, power = ls.autopower(nyquist_factor=500,\n",
     "                                minimum_frequency=0.2)"

--- a/figures/StructuredWindows.ipynb
+++ b/figures/StructuredWindows.ipynb
@@ -151,7 +151,7 @@
     }
    ],
    "source": [
-    "from astropy.stats import LombScargle\n",
+    "from astropy.timeseries import LombScargle\n",
     "\n",
     "ls = LombScargle(data.t, 1, fit_mean=False, center_data=False)\n",
     "freqW, powerW = ls.autopower(minimum_frequency=0, maximum_frequency=24)\n",

--- a/figures/Uncertainty.ipynb
+++ b/figures/Uncertainty.ipynb
@@ -12,7 +12,7 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "from cycler import cycler\n",
-    "from astropy.stats import LombScargle\n",
+    "from astropy.timeseries import LombScargle\n",
     "\n",
     "plt.style.use('seaborn-whitegrid')"
    ]

--- a/figures/WindowFunctions.ipynb
+++ b/figures/WindowFunctions.ipynb
@@ -26,7 +26,7 @@
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from astropy.stats import LombScargle\n",
+    "from astropy.timeseries import LombScargle\n",
     "\n",
     "plt.style.use('seaborn-whitegrid')"
    ]


### PR DESCRIPTION
Fix import warning as LombScargle was moved from astropy.stats to astropy.timeseries in recent versions of the astropy package.
This branch already includes the small change to fix the url of the Kepler data.